### PR TITLE
Update cl-cytoscape usage

### DIFF
--- a/src/lisp/tirun-jupyter/tirun-jupyter.lisp
+++ b/src/lisp/tirun-jupyter/tirun-jupyter.lisp
@@ -161,40 +161,36 @@
 
 (defun cyto-label ()
   (let ((widget *cyto-widget*))
-    (setf (cytoscape:cytoscape-style widget)
-          (append (cytoscape:cytoscape-style widget) (list (jupyter:json-new-obj
-                                                            ("selector" "node[label]")
-                                                            ("style" (jupyter:json-new-obj
-                                                                      ("label" "data(label)"))))
-                                                           (jupyter:json-new-obj
-                                                            ("selector" "edge[label]")
-                                                            ("style" (jupyter:json-new-obj
-                                                                      ("label" "data(label)"))))))))
+    (setf (cytoscape:graph-style widget)
+          (append (cytoscape:graph-style widget)
+                  (list (jupyter:json-new-obj
+                          ("selector" "node[label]")
+                          ("style" (jupyter:json-new-obj
+                                     ("label" "data(label)"))))
+                        (jupyter:json-new-obj
+                          ("selector" "edge[label]")
+                          ("style" (jupyter:json-new-obj
+                                     ("label" "data(label)"))))))))
   nil)
 
 
 (defvar *cyto-widget*)
 (defun cyto-graph (&optional (all-nodes *all-nodes*) (all-edges *all-edges*))
-  (let* ((all-nodes (loop for name in all-nodes
-                          collect (make-instance 'cytoscape:node :data (list (cons "id" (string name)) (cons "label" (string name))))))
-         (all-edges (loop for edge in all-edges
-                          collect (destructuring-bind (name1 name2 score)
-                                      edge
-                                    (make-instance 'cytoscape:edge
-                                                   :data (list (cons "source" (string name1))
-                                                               (cons "target" (string name2))
-                                                               (cons "label" (format nil "~3,2f" score))))))))
-    (let* ((graph (make-instance 'cytoscape:graph
-                                 :nodes all-nodes
-                                 :edges all-edges))
-           (widget (make-instance 'cytoscape:cytoscape-widget
-                                  :graph graph
-                                  :cytoscape-layout (list (cons "name" "cose")
-                                                          (cons "quality" "default")
-                                  ))))
-      (setf *cyto-widget* widget)
-      (cyto-label)
-      widget)))
+  (let ((all-nodes (loop for name in all-nodes
+                         collect (make-instance 'cytoscape:element
+                                                :group "nodes"
+                                                :data (list (cons "id" (string name)) (cons "label" (string name))))))
+        (all-edges (loop for edge in all-edges
+                         collect (destructuring-bind (name1 name2 score)
+                                                     edge
+                                   (make-instance 'cytoscape:element
+                                                  :group "edges"
+                                                  :data (list (cons "source" (string name1))
+                                                              (cons "target" (string name2))
+                                                              (cons "label" (format nil "~3,2f" score))))))))
+    (setf *cyto-widget* (make-instance 'cytoscape:cytoscape-widget :elements (append all-nodes all-edges)))
+    (cyto-label)
+    *cyto-widget*))
 
     
 


### PR DESCRIPTION
cl-cytoscape model matches cytoscape.js closer now.

# Changes
- No separate `graph` slot, replaced by `elements` slot
- Nodes and edges are represented by same base class `element` with `:group "nodes"` for nodes and `:group "edges"` for edges.
- Renamed `cytoscape-layout` slot to `graph-layout`
- Renamed `cytoscape-style` slot to `graph-style`