### PR TITLE
Fix cando-jupyter installer

### DIFF
--- a/src/lisp/cando-jupyter/kernel.lisp
+++ b/src/lisp/cando-jupyter/kernel.lisp
@@ -145,6 +145,7 @@
       (or implementation
           (first (uiop:raw-command-line-arguments))
           (format nil "~(~A~)" (uiop:implementation-type)))
+      "-f" "no-auto-lparallel"
       "--eval" "(ql:quickload :cando-jupyter)"
       "--eval" "(jupyter:run-kernel 'cando-jupyter:kernel #\"{connection_file}\")")))
 
@@ -155,6 +156,7 @@
       (or implementation
           (first (uiop:raw-command-line-arguments))
           (format nil "~(~A~)" (uiop:implementation-type)))
+      "-f" "no-auto-lparallel"
       "--load" (namestring (jupyter:installer-path instance :root :program :bundle))
       "--eval" "(asdf:load-system :cando-jupyter)"
       "--eval" "(jupyter:run-kernel 'cando-jupyter:kernel #\"{connection_file}\")")))


### PR DESCRIPTION
Update command line in installer. Not used by deploy, but still useful for user based installs.

