### PR TITLE
Add remove-partial-rings key to compare-molecules

### DIFF
--- a/src/lisp/molecule-graph/max-clique.lisp
+++ b/src/lisp/molecule-graph/max-clique.lisp
@@ -263,7 +263,7 @@ The last constraint abs(T(v1,v1')-T(v2,v2'))<=theta is the topological constrain
                                           (or (zerop (length neighbors)) ; no neighbors
                                               (and (= 1 (length neighbors)) ; one neighbor and they are in the ring
                                                    (position (first neighbors) ring))))
-                                 (setf new-equiv (delete atom new-equiv :key #'cdr))
+                                 (setf new-equiv (remove atom new-equiv :key #'cdr))
                                  (setf changed t)))))
         finally (return new-equiv)))
 

--- a/src/lisp/tirun-jupyter/tirun-jupyter.lisp
+++ b/src/lisp/tirun-jupyter/tirun-jupyter.lisp
@@ -676,13 +676,7 @@ It will put those multiple ligands into all-ligands and selected-ligands"
 (defun generate-stylesheet (atoms)
   (when atoms
     (with-output-to-string (output-stream)
-      (format output-stream "~{.atom.~A~^,~%~}" atoms)
-      (loop for atom-1 in atoms
-            for pos-1 from 0
-            do (loop for atom-2 in atoms
-                     for pos-1 below pos-1
-                     do (format output-stream "~%,.bond.~A.~A" atom-1 atom-2)))
-      (format output-stream " {~%  filter: url(#highlight);~%}"))))
+      (format output-stream "~{.~A~^,~%~} {~%  filter: url(#highlight);~%}" atoms))))
 
 
 (defun update-selected-sketches (graph unselected-names)

--- a/src/lisp/tirun/tirun-from-structures.lisp
+++ b/src/lisp/tirun/tirun-from-structures.lisp
@@ -96,6 +96,7 @@
        target-molecule
        :atom-match-callback (lambda (atom1 atom2)
                               (chem:atom-within-angstroms atom1 atom2 0.3))
+       :remove-partial-rings t
        :exclude-hydrogens t)
     (integrate-hydrogens-into-comparison heavy-equivs heavy-diff1 heavy-diff2)))
 


### PR DESCRIPTION
This makes it possible to use the partial ring removal in the highlighter. It does affect the TI calculations so needs to be reviewed.