### PR TITLE
fix some build problems

### DIFF
--- a/include/cando/chem/alias.h
+++ b/include/cando/chem/alias.h
@@ -35,6 +35,7 @@ This is an open source license for the CANDO software from Temple University, bu
 #include <vector>
 #include <set>
 #include <clasp/core/common.h>
+#include <clasp/core/symbol.h>
 #include <cando/geom/vector3.h>
 
 

--- a/include/cando/chem/elements.h
+++ b/include/cando/chem/elements.h
@@ -140,7 +140,7 @@ public:
 namespace translate
 {
   template <>
-    struct translate::from_object<chem::Element>
+  struct from_object<chem::Element>
   {
     typedef	chem::Element ExpectedType;
     typedef	chem::Element DeclareType;
@@ -171,7 +171,7 @@ namespace translate
   };
 
   template <>
-    struct translate::from_object<chem::Hybridization>
+    struct from_object<chem::Hybridization>
   {
     typedef	chem::Hybridization ExpectedType;
     typedef	chem::Hybridization DeclareType;


### PR DESCRIPTION
Specifically: in elements.h the translate:: is redundant since we are already in the translate namespace, and that causes a warning.

In the other file we -> into a Symbol_sp even though symbol.h was not directly included. It was included transiently but I rearranged that away in Clasp in a branch.